### PR TITLE
Bring the liveboard alive.

### DIFF
--- a/DGTCentaurMods/web/app.py
+++ b/DGTCentaurMods/web/app.py
@@ -5,7 +5,10 @@ app = Flask(__name__)
 
 @app.route("/")
 def index():
-	fen = "rnbqkbnr/pppp1ppp/4p3/8/3P4/8/PPP1PPPP/RNBQKBNR"
-	return render_template('index.html', fen=fen)
+    fenlog = "/home/pi/centaur/fen.log"
+    with open(fenlog, "r") as f:
+        line = f.readline().split(' ')
+        fen = line[0]
+    return render_template('index.html', fen=fen)
 
 

--- a/DGTCentaurMods/web/templates/liveboard.html
+++ b/DGTCentaurMods/web/templates/liveboard.html
@@ -25,6 +25,9 @@
             var queryString = "?t=" + timestamp;
             el.src = imgURL + queryString;
         }
-        setInterval('refreshImage("epaper","/static/epaper.jpg")', 1000);
+        setInterval('refreshImage("epaper","/static/epaper.jpg")', 2000);
+        setTimeout(function(){
+            window.location.reload(1);
+        }, 2000); 
     </script>
 </div>


### PR DESCRIPTION
Integrated with live movements in centaur software. For this to work you need the recompiled stockfish which print fen.log. I don't want to put stockfish compiled inside the repo so it doesn't overwhelm clonning it. 
Should be very easy to compile the one in my repos.

For lichess and others you just have to add in app.py a way to grab the FEN from the other game software. I saw you use python-chess in lichess. Just throw that in the same fen.log file in centaur... That would be my way to do it.
I just don't want to mess the code in lichess as I don't have a way to test it...

If I try to refresh just the div element but the calls to app.py stops, so no fen is returned and board dissapears. Solution was to simply refresh the entire page.

I reduced epaper display refresh to match the page refresh.