### PR TITLE
Disable console over serial on setup.

### DIFF
--- a/build/control
+++ b/build/control
@@ -2,6 +2,6 @@ Package: dgtcentaurmods
 Version: 0
 Architecture: armhf
 Maintainer: wormstein<email@gmail.com>
-Depends: ntp, ssmtp, libopenjp2-7-dev, libtiff5
+Depends: ntp, ssmtp, libopenjp2-7-dev, libtiff5, python3-pip
 Homepage: https://github.com/EdNekebno/DGTCentaur
 Description: DGT Centaur Mods is a set of new features to the DGT Centaur computer chess board.

--- a/build/postinst
+++ b/build/postinst
@@ -4,6 +4,8 @@
 #### HARDWARE CONFIGURATION
 CONFIG="/boot/config.txt"
 SETUP_DIR=/home/pi/DGTCentaurMods
+CMDLINEFILE=/boot/cmdline.txt
+NEWCMDFILE=/tmp/cmdline.txt
 
 echo -e "Hardware configuration"
 # Enabke SPI bus if not enbaled
@@ -32,6 +34,10 @@ echo "::: Checking serial port. "
     else
         sed -i "s/#enable_uart=1/enable_uart=1/g" $CONFIG
     fi
+    echo -e "::: Disable console on ttyS0"
+        sed 's/[^ ]* *//' $CMDLINEFILE > $NEWCMDFILE
+        sudo mv $NEWCMDFILE $CMDLINEFILE
+        sudo chown root.root $CMDLINEFILE
 
 ##### Enable systemd services.
 echo -e "Services setup\n"


### PR DESCRIPTION
Final tests tomorrow on a clean install.
I hope the cmdline.txt file structure don't change... It works for now.

Apparently, the menu wants to start but fails on reading data from serial because,,, of course, this is a RPi that's not the actual board :))