### PR TITLE
allow override computer moves in uci play

### DIFF
--- a/DGTCentaurMods/opt/DGTCentaurMods/game/gamemanager.py
+++ b/DGTCentaurMods/opt/DGTCentaurMods/game/gamemanager.py
@@ -491,7 +491,7 @@ def startClock():
     clockthread.daemon = True
     clockthread.start()
 
-def computerMove(mv):
+def computerMove(mv, forced = True):
     # Set the computer move that the player is expected to make
     # in the format b2b4 , g7g8q , etc
     global computermove
@@ -500,7 +500,8 @@ def computerMove(mv):
         return
     # First set the globals so that the thread knows there is a computer move
     computermove = mv
-    forcemove = 1
+    if forced == True:
+        forcemove = 1
     # Next indicate this on the board. First convert the text representation to the field number
     fromnum = ((ord(mv[1:2]) - ord("1")) * 8) + (ord(mv[0:1]) - ord("a"))
     tonum = ((ord(mv[3:4]) - ord("1")) * 8) + (ord(mv[2:3]) - ord("a"))

--- a/DGTCentaurMods/opt/DGTCentaurMods/game/uci.py
+++ b/DGTCentaurMods/opt/DGTCentaurMods/game/uci.py
@@ -142,7 +142,7 @@ def eventCallback(event):
             limit = chess.engine.Limit(time=5)
             mv = pengine.play(gamemanager.cboard, limit, info=chess.engine.INFO_ALL)
             mv = mv.move
-            gamemanager.computerMove(str(mv))                 
+            gamemanager.computerMove(str(mv), False)                 
     if event == gamemanager.EVENT_BLACK_TURN:
         curturn = 0
         if graphson == 1:            
@@ -158,7 +158,7 @@ def eventCallback(event):
             limit = chess.engine.Limit(time=5)
             mv = pengine.play(gamemanager.cboard, limit, info=chess.engine.INFO_ALL)
             mv = mv.move
-            gamemanager.computerMove(str(mv))        
+            gamemanager.computerMove(str(mv), False)        
     if event == gamemanager.EVENT_RESIGN_GAME:
         gamemanager.resignGame(computeronturn + 1)
 


### PR DESCRIPTION
This is a feature I managed to write in 4 words. Was worried I might need to refactor the whole thing. But no. 4 words. Yay me!

In uci mode (so playing against engines) you are no longer forced to follow the computer move if you don't want to.