### PR TITLE
add takebacks to gamemanager uci and 1v1Analysis

### DIFF
--- a/DGTCentaurMods/opt/DGTCentaurMods/game/1v1Analysis.py
+++ b/DGTCentaurMods/opt/DGTCentaurMods/game/1v1Analysis.py
@@ -150,6 +150,20 @@ def moveCallback(move):
     # This function receives valid moves made on the board
     # Note: the board state is in python-chess object gamemanager.board
     pass
+
+def takebackCallback():
+    # This function gets called when the user takes back a move   
+    global curturn     
+    # First the turn switches
+    if curturn == 1:
+        curturn = 0
+    else:
+        curturn = 1    
+    # Now call eventCallback from the new state
+    if curturn == 0:
+        eventCallback(gamemanager.EVENT_BLACK_TURN)    
+    else:
+        eventCallback(gamemanager.EVENT_WHITE_TURN)
     
 def evaluationGraphs(info):
     # Draw the evaluation graphs to the screen
@@ -320,7 +334,7 @@ epaper.initEpaper()
 #epaper.pauseEpaper()
 
 # Subscribe to the game manager to activate the previous functions
-gamemanager.subscribeGame(eventCallback, moveCallback, keyCallback)
+gamemanager.subscribeGame(eventCallback, moveCallback, keyCallback, takebackCallback)
 writeTextLocal(0,"Place pieces in")
 writeTextLocal(1,"Starting Pos")
 

--- a/DGTCentaurMods/opt/DGTCentaurMods/game/uci.py
+++ b/DGTCentaurMods/opt/DGTCentaurMods/game/uci.py
@@ -216,6 +216,20 @@ def moveCallback(move):
     # Note: the board state is in python-chess object gamemanager.cboard
     pass
 
+def takebackCallback():
+    # This function gets called when the user takes back a move   
+    global curturn     
+    # First the turn switches
+    if curturn == 1:
+        curturn = 0
+    else:
+        curturn = 1    
+    # Now call eventCallback from the new state
+    if curturn == 0:
+        eventCallback(gamemanager.EVENT_BLACK_TURN)    
+    else:
+        eventCallback(gamemanager.EVENT_WHITE_TURN)
+
 def evaluationGraphs(info):
     # Draw the evaluation graphs to the screen
     global firstmove
@@ -386,7 +400,7 @@ epaper.initEpaper()
 curturn = 1
 
 # Subscribe to the game manager to activate the previous functions
-gamemanager.subscribeGame(eventCallback, moveCallback, keyCallback)
+gamemanager.subscribeGame(eventCallback, moveCallback, keyCallback, takebackCallback)
 writeTextLocal(0,"Place pieces in")
 writeTextLocal(1,"Starting Pos")
 


### PR DESCRIPTION
Gamemanager maintains a list of board states. Then if it is called with a takeback function in the calling script it will update the database if the board has moved back a state and call that function to alert the calling script that a takeback has been made.

Or in other words playing against engines of 1v1Analysis now has takeback support.