### PR TITLE
Allow override resources with own in network share

### DIFF
--- a/DGTCentaurMods/opt/DGTCentaurMods/board/board.py
+++ b/DGTCentaurMods/opt/DGTCentaurMods/board/board.py
@@ -25,6 +25,7 @@ import serial
 import sys
 import os
 from DGTCentaurMods.display import epd2in9d, epaper
+from DGTCentaurMods.display.ui_components import AssetManager
 from DGTCentaurMods.board import centaur
 import time
 from PIL import Image, ImageDraw, ImageFont
@@ -77,7 +78,7 @@ else:
         ser.close()
         ser.open()
 
-font18 = ImageFont.truetype(str(pathlib.Path(__file__).parent.resolve()) + "/../resources/Font.ttc", 18)
+font18 = ImageFont.truetype(AssetManager.get_resource_path("Font.ttc"), 18)
 time.sleep(2)
 
 
@@ -201,7 +202,7 @@ def sleepScreen():
 
 def drawBoard(pieces):
     global screenbuffer
-    chessfont = Image.open(str(pathlib.Path(__file__).parent.resolve()) + "/../resources/chesssprites.bmp")
+    chessfont = Image.open(AssetManager.get_resource_path("chesssprites.bmp"))
     image = screenbuffer.copy()
     for x in range(0,64):
         pos = (x - 63) * -1
@@ -334,8 +335,8 @@ def doMenu(items, fast = 0):
             draw.polygon([(2, (selected * 20) + 2), (2, (selected * 20) + 18),
                           (18, (selected * 20) + 10)], fill=0)
             # Draw an image representing internet connectivity
-            wifion = Image.open(str(pathlib.Path(__file__).parent.resolve()) + "/../resources/wifiontiny.bmp")
-            wifioff = Image.open(str(pathlib.Path(__file__).parent.resolve()) + "/../resources/wifiofftiny.bmp")
+            wifion = Image.open(AssetManager.get_resource_path("wifiontiny.bmp"))
+            wifioff = Image.open(AssetManager.get_resource_path("wifiofftiny.bmp"))
             if connected == True:
                 wifidispicon = wifion.resize((20,16))
                 image.paste(wifidispicon, (105, 5))

--- a/DGTCentaurMods/opt/DGTCentaurMods/display/epaper.py
+++ b/DGTCentaurMods/opt/DGTCentaurMods/display/epaper.py
@@ -28,6 +28,7 @@
 from DGTCentaurMods.board import centaur,board
 from DGTCentaurMods.display import epd2in9d
 from DGTCentaurMods.display.epaper_driver import epaperDriver
+from DGTCentaurMods.display.ui_components import AssetManager
 import os, time
 from PIL import Image, ImageDraw, ImageFont
 import pathlib
@@ -41,7 +42,7 @@ except:
 
 driver = epaperDriver()
 
-font18 = ImageFont.truetype(str(pathlib.Path(__file__).parent.resolve()) + "/../resources/Font.ttc", 18)
+font18 = ImageFont.truetype(AssetManager.get_resource_path("Font.ttc"), 18)
 # Screenbuffer is what we want to display on the screen
 epaperbuffer = Image.new('1', (128, 296), 255) # You can also use pillow to directly change this image
 lastepaperhash = 0
@@ -84,7 +85,7 @@ def epaperUpdate():
             if screensleep == 1:
                 driver.reset()
                 screensleep = 0
-            filename = str(pathlib.Path(__file__).parent.resolve()) + "/../web/static/epaper.jpg"
+            filename = str(AssetManager.get_resource_path("epaper.jpg"))
             epaperbuffer.save(filename)
             if screeninverted == 0:
                 im = im.transpose(Image.FLIP_TOP_BOTTOM)
@@ -130,7 +131,7 @@ def refresh():
 def loadingScreen():
     global epaperbuffer
     statusBar().print()
-    filename = str(pathlib.Path(__file__).parent.resolve()) + "/../resources/logo_mods_screen.jpg"
+    filename = str(AssetManager.get_resource_path("logo_mods_screen.jpg"))
     lg = Image.open(filename)
     epaperbuffer.paste(lg,(0,20))
     writeText(10,'     Loading')
@@ -140,7 +141,7 @@ def loadingScreen():
 def welcomeScreen():
     global epaperbuffer
     statusBar().print()
-    filename = str(pathlib.Path(__file__).parent.resolve()) + "/../resources/logo_mods_screen.jpg"
+    filename = str(AssetManager.get_resource_path("logo_mods_screen.jpg"))
     lg = Image.open(filename)
     epaperbuffer.paste(lg,(0,20))
     writeText(10,'     Press')
@@ -160,7 +161,7 @@ def standbyScreen(show):
         epaperbuffer.save(f)
         statusBar().print()
         
-        filename = str(pathlib.Path(__file__).parent.resolve()) + "/../resources/logo_mods_screen.jpg"
+        filename = str(AssetManager.get_resource_path("logo_mods_screen.jpg"))
         lg = Image.open(filename)
         epaperbuffer.paste(lg,(0,20))
         writeText(10,'   Press [>||]')
@@ -212,11 +213,11 @@ def stopEpaper():
     global lastepaperbytes
     global epaperbuffer
     global kill
-    filename = str(pathlib.Path(__file__).parent.resolve()) + "/../resources/logo_mods_screen.jpg"
+    filename = str(AssetManager.get_resource_path("logo_mods_screen.jpg"))
     lg = Image.open(filename)
     lgs = Image.new('1', (128, 296), 255)
     lgs.paste(lg,(0,0))
-    qrfile = str(pathlib.Path(__file__).parent.resolve()) + "/../resources/qr-support.png"
+    qrfile = str(AssetManger.get_resource_path("qr-support.png"))
     qr = Image.open(qrfile)
     qr = qr.resize((128,128))
     lgs.paste(qr,(0,160))
@@ -278,7 +279,7 @@ def clearScreen():
 def drawBoard(pieces, startrow=2):         
     global epaperbuffer
     draw = ImageDraw.Draw(epaperbuffer)
-    chessfont = Image.open(str(pathlib.Path(__file__).parent.resolve()) + "/../resources/chesssprites.bmp")
+    chessfont = Image.open(AssetManager.get_resource_path("chesssprites.bmp"))
     for x in range(0,64):
         pos = (x - 63) * -1
         row = ((startrow * 20) + 8) + (16 * (pos // 8))
@@ -342,7 +343,7 @@ def promotionOptions(row):
     global epaperbuffer
     logging.debug("drawing promotion options")
     global epaperprocesschange
-    font18 = ImageFont.truetype(str(pathlib.Path(__file__).parent.resolve()) + "/../resources/Font.ttc", 18)
+    font18 = ImageFont.truetype(AssetManager.get_resource_path("Font.ttc"), 18)
     writeText(13, "                    ")
     if epaperprocesschange == 1:    
         offset = row * 20
@@ -361,7 +362,7 @@ def promotionOptions(row):
     else:
         timage = Image.new('1', (128, 20), 255)
         draw = ImageDraw.Draw(timage)
-        font18 = ImageFont.truetype(str(pathlib.Path(__file__).parent.resolve()) + "/../resources/Font.ttc", 18)
+        font18 = ImageFont.truetype(AssetManager.get_resource_path("Font.ttc"), 18)
         draw.text((0, 0), "    Q    R    N    B", font=font18, fill=0)      
         offset = 0
         draw.polygon([(2, offset+18), (18, offset+18), (10, offset+3)], fill=0)
@@ -393,7 +394,7 @@ def resignDrawMenu(row):
         # If epaperprocesschange is 0 then assume that the app calling is using the new partial display functions
         timage = Image.new('1', (128, 20), 255)
         draw = ImageDraw.Draw(timage)
-        font18 = ImageFont.truetype(str(pathlib.Path(__file__).parent.resolve()) + "/../resources/Font.ttc", 18)
+        font18 = ImageFont.truetype(AssetManager.get_resource_path("Font.ttc"), 18)
         draw.text((0, 0), "    DRW    RESI", font=font18, fill=0)
         draw.polygon([(2, 18), (18, 18), (10, 3)], fill=0)
         draw.polygon([(35+25, 3), (51+25, 3), (43+25, 18)], fill=0)
@@ -455,7 +456,7 @@ def drawWindow(x, y, w, data):
         if tw >= dw:
             tw = 0
             dyoff = dyoff + 1
-    filename = str(pathlib.Path(__file__).parent.resolve()) + "/../web/static/epaper.jpg"
+    filename = str(AssetManger.get_resource_path("epaper.jpg"))
     epaperbuffer.save(filename)    
 
 def drawImagePartial(x, y, img):
@@ -478,7 +479,7 @@ def drawBatteryIndicator():
         if board.batterylevel == 20:
             batteryindicator = "batterycf"    
     if board.batterylevel >= 0:
-        img = Image.open(str(pathlib.Path(__file__).parent.resolve()) + "/../resources/" + batteryindicator + ".bmp")
+        img = Image.open(AssetManager.get_resource_path(batteryindicator + ".bmp"))
         epaperbuffer.paste(img,(98, 2))        
         #drawImagePartial(13,0,img)     
 
@@ -550,7 +551,7 @@ class MenuDraw:
             im = im.transpose(Image.FLIP_TOP_BOTTOM)
             im = im.transpose(Image.FLIP_LEFT_RIGHT)
         bytes = im.tobytes()
-        filename = str(pathlib.Path(__file__).parent.resolve()) + "/../web/static/epaper.jpg"
+        filename = str(AssetManager.get_resource_path("epaper.jpg"))
         epaperbuffer.save(filename)
         epd.send_command(0x91)
         epd.send_command(0x90)
@@ -593,7 +594,7 @@ class MenuDraw:
         draw = ImageDraw.Draw(epaperbuffer)
         draw.rectangle([(0, 40), (8, 191)], fill = 255, outline = 255)
         draw.rectangle([(2,((index + 2) * 20) + 5), (8, ((index+2) * 20) + 14)], fill = 0, outline = 0)
-        filename = str(pathlib.Path(__file__).parent.resolve()) + "/../web/static/epaper.jpg"
+        filename = str(AssetManger.get_resource_path("epaper.jpg"))
         epaperbuffer.save(filename)
         epd.send_command(0x91) # Enter partial mode
         epd.send_command(0x90) # Set resolution

--- a/DGTCentaurMods/opt/DGTCentaurMods/display/ui_components.py
+++ b/DGTCentaurMods/opt/DGTCentaurMods/display/ui_components.py
@@ -1,0 +1,42 @@
+""" Provides the classes and components for the ui interface """
+
+# DGT Centaur display control functions
+#
+# This file is part of the DGTCentaur Mods open source software
+# ( https://github.com/EdNekebno/DGTCentaur )
+#
+# DGTCentaur Mods is free software: you can redistribute
+# it and/or modify it under the terms of the GNU General Public
+# License as published by the Free Software Foundation, either
+# version 3 of the License, or (at your option) any later version.
+#
+# DGTCentaur Mods is distributed in the hope that it will
+# be useful, but WITHOUT ANY WARRANTY; without even the implied warranty
+# of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this file.  If not, see
+#
+# https://github.com/EdNekebno/DGTCentaur/blob/master/LICENSE.md
+#
+# This and any other notices must remain intact and unaltered in any
+# distribution, modification, variant, or derivative of this software.
+
+import os
+
+class AssetManager():
+    """ Class representing epaperDriver Communications """
+
+    @staticmethod
+    def get_resource_path(resource_file):
+        """ Return resource path from the resources folder or /home/pi/resources """
+
+        if resource_file.find("..") >= 0:
+            return ""
+
+        if os.path.exists("/home/pi/resources/" + resource_file):
+            return "/home/pi/resources/" + resource_file
+        else:
+            return "/opt/DGTCentaurMods/resources/" + resource_file
+        

--- a/DGTCentaurMods/opt/DGTCentaurMods/game/1v1Analysis.py
+++ b/DGTCentaurMods/opt/DGTCentaurMods/game/1v1Analysis.py
@@ -23,7 +23,7 @@
 
 from DGTCentaurMods.game import gamemanager
 from DGTCentaurMods.display import epaper
-
+from DGTCentaurMods.display.ui_components import AssetManager
 import time
 import chess
 import chess.engine
@@ -112,7 +112,7 @@ def eventCallback(event):
         if event.startswith("Termination."):
             image = Image.new('1', (128, 12), 255)
             draw = ImageDraw.Draw(image)
-            font12 = ImageFont.truetype(str(pathlib.Path(__file__).parent.resolve()) + "/../resources/Font.ttc", 12)
+            font12 = ImageFont.truetype(AssetManager.get_resource_path("Font.ttc"), 12)
             txt = event[12:]
             draw.text((30, 0), txt, font=font12, fill=0)
             epaper.drawImagePartial(0, 221, image)
@@ -124,7 +124,7 @@ def eventCallback(event):
             # Let's display an end screen
             image = Image.new('1', (128,292), 255)
             draw = ImageDraw.Draw(image)
-            font18 = ImageFont.truetype(str(pathlib.Path(__file__).parent.resolve()) + "/../resources/Font.ttc", 18)
+            font18 = ImageFont.truetype(AssetManager.get_resource_path("Font.ttc"), 18)
             draw.text((0,0), "   GAME OVER", font=font18, fill = 0)
             draw.text((0,20), "          " + gamemanager.getResult(), font=font18, fill = 0)            
             if len(scorehistory) > 0:
@@ -193,7 +193,7 @@ def evaluationGraphs(info):
     if graphson == 1:
         image = Image.new('1', (128, 80), 255)
         draw = ImageDraw.Draw(image)
-        font12 = ImageFont.truetype(str(pathlib.Path(__file__).parent.resolve()) + "/../resources/Font.ttc", 12)
+        font12 = ImageFont.truetype(AssetManager.get_resource_path("Font.ttc"), 12)
     txt = "{:5.1f}".format(sval)        
     if sval > 999:
         txt = ""
@@ -246,7 +246,7 @@ def writeTextLocal(row,txt):
     # Write Text on a give line number
     image = Image.new('1', (128, 20), 255)
     draw = ImageDraw.Draw(image)
-    font18 = ImageFont.truetype(str(pathlib.Path(__file__).parent.resolve()) + "/../resources/Font.ttc", 18)
+    font18 = ImageFont.truetype(AssetManager.get_resource_path("Font.ttc"), 18)
     draw.text((0, 0), txt, font=font18, fill=0)
     epaper.drawImagePartial(0, (row*20), image)    
 
@@ -269,7 +269,7 @@ def drawBoardLocal(fen):
             nfen = nfen + curfen[((a - 1) * 8) + b]
     lboard = Image.new('1', (128, 128), 255)
     draw = ImageDraw.Draw(lboard)
-    chessfont = Image.open(str(pathlib.Path(__file__).parent.resolve()) + "/../resources/chesssprites.bmp")
+    chessfont = Image.open(AssetManager.get_resource_path("chesssprites.bmp"))
     for x in range(0,64):
         pos = (x - 63) * -1
         row = (16 * (pos // 8))

--- a/DGTCentaurMods/opt/DGTCentaurMods/game/menu.py
+++ b/DGTCentaurMods/opt/DGTCentaurMods/game/menu.py
@@ -31,6 +31,7 @@ import json
 import socket
 import subprocess
 import os
+from DGTCentaurMods.display.ui_components import AssetManager
 
 try:
     logging.basicConfig(level=logging.DEBUG, filename="/home/pi/debug.log",filemode="w")
@@ -897,11 +898,8 @@ while True:
         epaper.writeText(1, "Get support:")
         epaper.writeText(9, "DGTCentaur")
         epaper.writeText(10, "      Mods")
-        epaper.writeText(11, "Ver:" + version)
-        qr = Image.open(
-            str(pathlib.Path(__file__).parent.resolve())
-            + "/../resources/qr-support.png"
-        )
+        epaper.writeText(11, "Ver:" + version)        
+        qr = Image.open(AssetManager.get_resource_path("qr-support.png"))
         qr = qr.resize((128, 128))
         epaper.epaperbuffer.paste(qr, (0, 42))
         timeout = time.time() + 15

--- a/DGTCentaurMods/opt/DGTCentaurMods/game/pegasus.py
+++ b/DGTCentaurMods/opt/DGTCentaurMods/game/pegasus.py
@@ -25,6 +25,7 @@ import dbus
 from DGTCentaurMods.thirdparty.advertisement import Advertisement
 from DGTCentaurMods.thirdparty.service import Application, Service, Characteristic, Descriptor
 from DGTCentaurMods.board import *
+from DGTCentaurMods.display.ui_components import AssetManager
 import time
 import threading
 import os
@@ -51,7 +52,7 @@ statusbar = epaper.statusBar()
 statusbar.start()
 
 def displayLogo():
-    filename = str(pathlib.Path(__file__).parent.resolve()) + "/../resources/logo_mods_screen.jpg"
+    filename = str(AssetManager.get_resource_path("logo_mods_screen.jpg"))
     lg = Image.open(filename)
     lg = lg.resize((48,112))
     return epaper.epaperbuffer.paste(lg,(0,20))

--- a/DGTCentaurMods/opt/DGTCentaurMods/game/uci.py
+++ b/DGTCentaurMods/opt/DGTCentaurMods/game/uci.py
@@ -23,6 +23,7 @@
 
 from DGTCentaurMods.game import gamemanager
 from DGTCentaurMods.display import epaper
+from DGTCentaurMods.display.ui_components import AssetManager
 
 import time
 import chess
@@ -176,7 +177,7 @@ def eventCallback(event):
         if event.startswith("Termination."):
             image = Image.new('1', (128, 12), 255)
             draw = ImageDraw.Draw(image)
-            font12 = ImageFont.truetype(str(pathlib.Path(__file__).parent.resolve()) + "/../resources/Font.ttc", 12)
+            font12 = ImageFont.truetype(AssetManager.get_resource_path("Font.ttc"), 12)
             txt = event[12:]
             draw.text((30, 0), txt, font=font12, fill=0)
             epaper.drawImagePartial(0, 221, image)
@@ -189,7 +190,7 @@ def eventCallback(event):
             print("displaying end screen")
             image = Image.new('1', (128,292), 255)
             draw = ImageDraw.Draw(image)
-            font18 = ImageFont.truetype(str(pathlib.Path(__file__).parent.resolve()) + "/../resources/Font.ttc", 18)
+            font18 = ImageFont.truetype(AssetManager.get_resource_path("Font.ttc"), 18)
             draw.text((0,0), "   GAME OVER", font=font18, fill = 0)
             draw.text((0,20), "          " + gamemanager.getResult(), font=font18, fill = 0)            
             if len(scorehistory) > 0:
@@ -257,7 +258,7 @@ def evaluationGraphs(info):
     if graphson == 1:
         image = Image.new('1', (128, 80), 255)
         draw = ImageDraw.Draw(image)
-        font12 = ImageFont.truetype(str(pathlib.Path(__file__).parent.resolve()) + "/../resources/Font.ttc", 12)
+        font12 = ImageFont.truetype(AssetManager.get_resource_path("Font.ttc"), 12)
     txt = "{:5.1f}".format(sval)        
     if sval > 999:
         txt = ""
@@ -310,7 +311,7 @@ def writeTextLocal(row,txt):
     # Write Text on a give line number
     image = Image.new('1', (128, 20), 255)
     draw = ImageDraw.Draw(image)
-    font18 = ImageFont.truetype(str(pathlib.Path(__file__).parent.resolve()) + "/../resources/Font.ttc", 18)
+    font18 = ImageFont.truetype(AssetManager.get_resource_path("Font.ttc"), 18)
     draw.text((0, 0), txt, font=font18, fill=0)
     epaper.drawImagePartial(0, (row*20), image)    
 
@@ -333,7 +334,7 @@ def drawBoardLocal(fen):
             nfen = nfen + curfen[((a - 1) * 8) + b]
     lboard = Image.new('1', (128, 128), 255)
     draw = ImageDraw.Draw(lboard)
-    chessfont = Image.open(str(pathlib.Path(__file__).parent.resolve()) + "/../resources/chesssprites.bmp")
+    chessfont = Image.open(AssetManager.get_resource_path("chesssprites.bmp"))
     for x in range(0,64):
         pos = (x - 63) * -1
         row = (16 * (pos // 8))

--- a/DGTCentaurMods/opt/DGTCentaurMods/web/app.py
+++ b/DGTCentaurMods/opt/DGTCentaurMods/web/app.py
@@ -21,6 +21,7 @@
 
 from flask import Flask, render_template, Response, request, redirect
 from DGTCentaurMods.db import models
+from DGTCentaurMods.display.ui_components import AssetManager
 from chessboard import LiveBoard
 import centaurflask
 from PIL import Image, ImageDraw, ImageFont
@@ -748,18 +749,18 @@ def makePGN(gameid):
 	session.close()
 	return pgn_string
 
-pb = Image.open(str(pathlib.Path(__file__).parent.resolve()) + "/../resources/pb.png").convert("RGBA")
-pw = Image.open(str(pathlib.Path(__file__).parent.resolve()) + "/../resources/pw.png").convert("RGBA")
-rb = Image.open(str(pathlib.Path(__file__).parent.resolve()) + "/../resources/rb.png").convert("RGBA")
-bb = Image.open(str(pathlib.Path(__file__).parent.resolve()) + "/../resources/bb.png").convert("RGBA")
-nb = Image.open(str(pathlib.Path(__file__).parent.resolve()) + "/../resources/nb.png").convert("RGBA")
-qb = Image.open(str(pathlib.Path(__file__).parent.resolve()) + "/../resources/qb.png").convert("RGBA")
-kb = Image.open(str(pathlib.Path(__file__).parent.resolve()) + "/../resources/kb.png").convert("RGBA")
-rw = Image.open(str(pathlib.Path(__file__).parent.resolve()) + "/../resources/rw.png").convert("RGBA")
-bw = Image.open(str(pathlib.Path(__file__).parent.resolve()) + "/../resources/bw.png").convert("RGBA")
-nw = Image.open(str(pathlib.Path(__file__).parent.resolve()) + "/../resources/nw.png").convert("RGBA")
-qw = Image.open(str(pathlib.Path(__file__).parent.resolve()) + "/../resources/qw.png").convert("RGBA")
-kw = Image.open(str(pathlib.Path(__file__).parent.resolve()) + "/../resources/kw.png").convert("RGBA")
+pb = Image.open(AssetManager.get_resource_path("pb.png")).convert("RGBA")
+pw = Image.open(AssetManager.get_resource_path("pw.png")).convert("RGBA")
+rb = Image.open(AssetManager.get_resource_path("rb.png")).convert("RGBA")
+bb = Image.open(AssetManager.get_resource_path("bb.png")).convert("RGBA")
+nb = Image.open(AssetManager.get_resource_path("nb.png")).convert("RGBA")
+qb = Image.open(AssetManager.get_resource_path("qb.png")).convert("RGBA")
+kb = Image.open(AssetManager.get_resource_path("kb.png")).convert("RGBA")
+rw = Image.open(AssetManager.get_resource_path("rw.png")).convert("RGBA")
+bw = Image.open(AssetManager.get_resource_path("bw.png")).convert("RGBA")
+nw = Image.open(AssetManager.get_resource_path("nw.png")).convert("RGBA")
+qw = Image.open(AssetManager.get_resource_path("qw.png")).convert("RGBA")
+kw = Image.open(AssetManager.get_resource_path("kw.png")).convert("RGBA")
 logo = Image.open(str(pathlib.Path(__file__).parent.resolve()) + "/../web/static/logo_mods_web.png")
 moddate = -1
 sc = None


### PR DESCRIPTION
This is the start of the new UI system. A simple change that checks if a requested graphic from https://github.com/EdNekebno/DGTCentaurMods/tree/master/DGTCentaurMods/opt/DGTCentaurMods/resources exists in /home/pi/resources. This means if someone creates a folder called resources in their network share then they can place images there to override the default ones. For example, create the resources folder, download the file to change from the repo resources folder, modify it, then that is used instead.